### PR TITLE
Fix processing enclosed captions in shortcaps.py

### DIFF
--- a/bin/shortcaps.py
+++ b/bin/shortcaps.py
@@ -34,25 +34,23 @@ def process_caption(caption):
 
 
 def process_lines(lines_in):
-    """Process captions in a file, parsing it line by line.
+    r"""Process captions in a file, parsing it line by line.
 
     >>> process_lines(['\\hypertarget{', '\\caption{short;;long}', '}'])
     ['\\hypertarget{', '\\caption[short]{long}', '}']
 
     """
-    incaption = False
     caption = None
     lines_out = []
     for line in lines_in:
-        if incaption:
-            caption += line
+        if r'\caption{' in line:
+            caption = line
+        if caption:
             if caption.count(r'{') - caption.count(r'}') == 0:
                 lines_out.append(process_caption(caption))
-                incaption = False
                 caption = None
-        elif r'\caption{' in line:
-            incaption = True
-            caption = line
+            elif caption:
+                caption += line
         else:
             lines_out.append(line)
     return lines_out

--- a/bin/shortcaps.py
+++ b/bin/shortcaps.py
@@ -33,11 +33,15 @@ def process_caption(caption):
     return caption
 
 
-if __name__ == '__main__':
+def process_lines(lines_in):
+    """Process captions in a file, parsing it line by line.
+
+    >>> process_lines(['\\hypertarget{', '\\caption{short;;long}', '}'])
+    ['\\hypertarget{', '\\caption[short]{long}', '}']
+
+    """
     incaption = False
     caption = None
-    with open(sys.argv[1], 'r') as f:
-        lines_in = f.readlines()
     lines_out = []
     for line in lines_in:
         if incaption:
@@ -51,6 +55,12 @@ if __name__ == '__main__':
             caption = line
         else:
             lines_out.append(line)
+    return lines_out
 
+
+if __name__ == '__main__':
+    with open(sys.argv[1], 'r') as f:
+        lines_in = f.readlines()
+    lines_out = process_lines(lines_in)
     with open(sys.argv[1], 'w') as f:
         print(''.join(lines_out), file=f, end='')


### PR DESCRIPTION
Checkout b90d4dc and run `python3 -m doctest bin/shortcaps.py` for a demonstration of the bug. Second commit fixes it by less aggressively including following lines. 